### PR TITLE
Fix issue where fields defined within union types were not found

### DIFF
--- a/src/main/java/org/mihkel/avro/io/ExtendedJsonDecoder.java
+++ b/src/main/java/org/mihkel/avro/io/ExtendedJsonDecoder.java
@@ -741,6 +741,10 @@ public class ExtendedJsonDecoder extends ParsingDecoder
 	}
 	
 	private static Field findField(Schema schema, String name) {
+		if (Schema.Type.NULL.equals(schema.getType())) {
+			return null;
+		}
+
 		if (schema.getField(name) != null) {
 			return schema.getField(name);
 		}
@@ -755,8 +759,15 @@ public class ExtendedJsonDecoder extends ParsingDecoder
 				foundField = findField(fieldSchema.getElementType(), name);
 			} else if (Type.MAP.equals(fieldSchema.getType())) {
 				foundField = findField(fieldSchema.getValueType(), name);
+			} else if (Schema.Type.UNION.equals(fieldSchema.getType())) {
+				for (Schema unionType : fieldSchema.getTypes()) {
+					foundField = findField(unionType, name);
+					if (foundField != null) {
+						break;
+					}
+				}
 			}
-			
+
 			if (foundField != null) {
 				return foundField;
 			}

--- a/src/test/java/org/mihkel/avro/io/ExtendedJsonDecoderTest.java
+++ b/src/test/java/org/mihkel/avro/io/ExtendedJsonDecoderTest.java
@@ -118,7 +118,17 @@ public class ExtendedJsonDecoderTest extends TestCase {
 		GenericRecord record = readRecord(w, data);
 		Assert.assertNull(record.get("S"));
 	}
-	
+
+	@Test
+	public void testNestedOptionals() throws IOException {
+		String w = "{\"type\":\"record\",\"name\":\"rootType\",\"fields\":[{\"name\":\"outer\",\"type\":" +
+				"[\"null\",{\"type\":\"record\",\"name\":\"outerType\",\"fields\":[{\"name\":\"innerField\",\"type\":[\"null\",\"string\"],\"default\":null}]}" +
+				"],\"default\":null}]}";
+		String data = "{\"outer\":{\"outerType\":{}}}";
+		GenericRecord record = readRecord(w, data);
+		Assert.assertNull(record.get("S"));
+	}
+
 	public GenericRecord readRecord(String schemaString, String jsonData) throws IOException {
 		Schema schema = Schema.parse(schemaString);
 		Decoder decoder = new ExtendedJsonDecoder(schema, jsonData);


### PR DESCRIPTION
It appears that an optional field defined within an optional record will not be found when looking for a default value.  This change seems to address that.